### PR TITLE
Add autoplay param for automated benchmark runs

### DIFF
--- a/cube2/js/game-setup.js
+++ b/cube2/js/game-setup.js
@@ -1,4 +1,3 @@
-
 // Setup compiled code parameters and interaction with the web page
 var Module = {
   failed: false,
@@ -211,6 +210,20 @@ Module.postLoadWorld = function() {
 
   if (replayingRecording) {
     Module.startupFinish = Recorder.pnow();
+
+    Recorder.onFinish.push(function() {
+      var now = Recorder.pnow();
+      var elapsedFromStart = now - Module.startupFinish;
+      console.log('elapsed from start : ' + elapsedFromStart + ' ms');
+      var cancelFS = document.mozCancelFullScreen || document.webkitCancelFullScreen;
+      cancelFS.call(document);
+    });
+
+    if (SearchArgs["autoplay"] == "low") {
+      setTimeout(function() { Module.fullscreenLow(); }, 100);
+    } else if (SearchArgs["autoplay"] == "high") {
+      setTimeout(function() { Module.fullscreenHigh(); }, 100);
+    }
   } else if (typeof Recorder != 'undefined') {
     Recorder.pnow(); // equalize between record and replay
   }

--- a/cube2/js/main.js
+++ b/cube2/js/main.js
@@ -1,3 +1,16 @@
+var SearchArgs = {};
+(function() {
+  var searchArgs = window.location.search.split("&");
+  for (var i = 0; i < searchArgs.length; ++i) {
+    var eqsplit = searchArgs[i].split("=");
+    if (eqsplit.length == 1) {
+      SearchArgs[eqsplit[0]] = true;
+    } else {
+      SearchArgs[eqsplit[0]] = eqsplit[1];
+    }
+  }
+})();
+
 (function(){
   
   var SLIDE_DURATION = 5000;


### PR DESCRIPTION
Adds 'autoplay' param, with 'low' or 'high' that can be used in
conjunction with the Firefox full-screen-api.allow-trusted-requests-only
flag for a fully automated run.
