### PR TITLE
Update README to point to sour

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 The BananaBread Engine
 ======================
 
+---
+
+Notice
+------
+BananaBread is no longer under active development. A fork of this project, [cfoust/sour](https://github.com/cfoust/sour), has continued the effort. Among other things, it adds support for multiplayer servers, upgrades the engine to the latest version of Sauerbraten, and supports all of the game's maps.
+
+---
+
 A port of the Cube 2/Sauerbraten 3D game engine/first person shooter to the
 web, compiling C++ and OpenGL to JavaScript and WebGL using Emscripten.
 


### PR DESCRIPTION
As mentioned in [this issue](https://github.com/cfoust/sour/issues/1) it may be nice to link to Sour from here. I've been doing a ton of work on Sour lately with support from the Sauerbraten community, so it seems reasonable to say there's a renewed effort there!

Let me know if I should make any adjustments to the description here; I just threw this together.